### PR TITLE
Adds parsing for resource group IDs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,18 +3,14 @@ locals {
 }
 
 locals {
+  subscription_id_index     = index(local.split_id, "subscriptions") + 1
+  subscription_id           = local.split_id[local.subscription_id_index]
   resource_group_name_index = index(local.split_id, "resourceGroups") + 1
   resource_group_name       = local.split_id[local.resource_group_name_index]
-
-  provider_namespace_index = index(local.split_id, "providers") + 1
-  provider_namespace       = local.split_id[local.provider_namespace_index]
-
-  subscription_id_index = index(local.split_id, "subscriptions") + 1
-  subscription_id       = local.split_id[local.subscription_id_index]
-
-  resource_type_index = local.provider_namespace_index + 1
-  resource_type       = local.split_id[local.resource_type_index]
-
-  resource_name_index = length(local.split_id) - 1
-  resource_name       = local.split_id[local.resource_name_index]
+  provider_namespace_index  = length(local.split_id) > 5 ? index(local.split_id, "providers") + 1 : null
+  provider_namespace        = local.provider_namespace_index != null ? local.split_id[local.provider_namespace_index] : null
+  resource_type_index       = local.provider_namespace_index != null ? local.provider_namespace_index + 1 : null
+  resource_type             = local.provider_namespace_index != null ? local.split_id[local.resource_type_index] : "resourceGroups"
+  resource_name_index       = length(local.split_id) - 1
+  resource_name             = local.split_id[local.resource_name_index]
 }


### PR DESCRIPTION
Previously, passing a resource group ID would result in an error:

```
| Error: Error in function call
│ 
│   on modules/azure-resource-id-parser/main.tf line 9, in locals:
│    9:   provider_namespace_index = index(local.split_id, "providers") + 1
│     ├────────────────
│     │ while calling index(list, value)
│     │ local.split_id is list of string with 5 elements
│ 
│ Call to function "index" failed: item not found.
```

Resolved error by only parsing `provider_namespace` and `resource_type` when `split_id` contains more than 5 elements. 